### PR TITLE
Respect env.ALL_CHANGED_FILES if present

### DIFF
--- a/git-changed-files.js
+++ b/git-changed-files.js
@@ -88,8 +88,8 @@ const gitChangedFiles = async (
     //       ALL_CHANGED_FILES: '${{ steps.changed.outputs.added_modified }}'
     //
     if (process.env.ALL_CHANGED_FILES) {
-        const files = JSON.parse(process.env.ALL_CHANGED_FILES)
-        return files.filter(path => !isFileIgnored(cwd, path))
+        const files = JSON.parse(process.env.ALL_CHANGED_FILES);
+        return files.filter((path) => !isFileIgnored(cwd, path));
     }
 
     const { stdout } = await execProm(


### PR DESCRIPTION
## Summary:
If it's absent, the fall back to the method that might give false positives.

Issue: https://khanacademy.atlassian.net/browse/FEI-3796

## Test plan:
This pull-request shows the new code in action https://github.com/Khan/eslint-action/pull/27/files