### PR TITLE
Fix getBaseRef to work when a directory has the same name as a branch

### DIFF
--- a/get-base-ref.js
+++ b/get-base-ref.js
@@ -15,7 +15,7 @@
  */
 const {execSync, spawnSync} = require('child_process');
 
-const checkRef = ref => spawnSync('git', ['rev-parse', ref]).status === 0;
+const checkRef = ref => spawnSync('git', ['rev-parse', ref, '--']).status === 0;
 
 const validateBaseRef = (baseRef /*:string*/) /*: string | null */ => {
     // It's locally accessible!

--- a/get-base-ref.js
+++ b/get-base-ref.js
@@ -15,6 +15,9 @@
  */
 const {execSync, spawnSync} = require('child_process');
 
+// NOTE: The final `--` tells git that `ref` is a branch name, and *not* a file or
+// directory name. Without it, git gets confused when there's a branch with the
+// same name as a directory.
 const checkRef = ref => spawnSync('git', ['rev-parse', ref, '--']).status === 0;
 
 const validateBaseRef = (baseRef /*:string*/) /*: string | null */ => {


### PR DESCRIPTION
## Summary:
Now that we're using the get-changed-files action, it might make sense to refactor the use of getBaseRef 🤔 because we only need it to calculate the changed files list. But anyway, this bug is easy to fix.

Issue: FEI-3819

## Test plan:
create a branch that's the same name as a folder in this project, then make a branch off of that and to a pull-request. It shouldn't error out.
Here's the PR I made to test it https://github.com/Khan/actions-utils/pull/17