### PR TITLE
Allow list-changed-files to work where main instead of master

### DIFF
--- a/list-changed-files.js
+++ b/list-changed-files.js
@@ -13,9 +13,10 @@ const getBaseRef = require('./get-base-ref');
 const gitChangedFiles = require('./git-changed-files');
 
 const run = async () => {
-    const baseRef = await getBaseRef();
-
-    // Note (Lilli): If baseRef is null for any reason, use `master` as opposed to failing the check silently
+    // Note (Lilli): If baseRef is null for any reason, see if we were
+    // given a default in our args, otherwise use `master` as opposed to
+    // failing the check silently
+    const baseRef = (await getBaseRef()) || process.argv[2] || 'master';
     const files = await gitChangedFiles(baseRef ? baseRef : 'master', '.');
     files.forEach(file => console.log(file));
 };


### PR DESCRIPTION
## Summary:
I discovered while updating eslint-action, that this code defaults to
master but many of our repos are now using main. I didn't want to
break things, so I just added support for the default base to be
overridden with an arg, like:

`./list-changed-files.js main`

Issue: FEI-4138

## Test plan:
Try in this repo:
`./list-changed-files.js` fails, but `./list-changed-files.js main` works as expected.