### PR TITLE
Add a function "get-changed-files-from-env" so we can avoid looking up the baseRef in actions

### DIFF
--- a/get-changed-files-from-env.js
+++ b/get-changed-files-from-env.js
@@ -1,0 +1,28 @@
+// @flow
+const isFileIgnored = require('./is-file-ignored');
+
+/**
+ * Github actions jobs can run the following steps to get a fully accurate
+ * changed files list. Otherwise, we fallback to a simple diff between the
+ * current and base branch, which might give false positives if the base
+ * is ahead of the current branch.
+ *
+ *   - name: Get All Changed Files
+ *     uses: jaredly/get-changed-files@absolute
+ *     id: changed
+ *     with:
+ *       format: 'json'
+ *       absolute: true
+ *
+ *   - uses: allenevans/set-env@v2.0.0
+ *     with:
+ *       ALL_CHANGED_FILES: '${{ steps.changed.outputs.added_modified }}'
+ */
+const getChangedFilesFromEnv = (cwd /*:string*/) /*: ?Array<string>*/ => {
+    if (process.env.ALL_CHANGED_FILES) {
+        const files /*: Array<string> */ = JSON.parse(process.env.ALL_CHANGED_FILES); // flow-uncovered-line
+        return files.filter(path => !isFileIgnored(cwd, path));
+    }
+};
+
+module.exports = getChangedFilesFromEnv;

--- a/git-changed-files.js
+++ b/git-changed-files.js
@@ -3,6 +3,7 @@ const execProm = require('./exec-prom');
 const path = require('path');
 const fs = require('fs');
 const isFileIgnored = require('./is-file-ignored');
+const getChangedFilesFromEnv = require('./get-changed-files-from-env');
 
 /**
  * This lists the files that have changed when compared to `base` (a git ref),
@@ -13,9 +14,9 @@ const isFileIgnored = require('./is-file-ignored');
 const gitChangedFiles = async (base /*:string*/, cwd /*:string*/) /*: Promise<Array<string>>*/ => {
     cwd = path.resolve(cwd);
 
-    if (process.env.ALL_CHANGED_FILES) {
-        const files /*: Array<string> */ = JSON.parse(process.env.ALL_CHANGED_FILES); // flow-uncovered-line
-        return files.filter(path => !isFileIgnored(cwd, path));
+    const fromEnv = getChangedFilesFromEnv(cwd);
+    if (fromEnv) {
+        return fromEnv;
     }
 
     const {stdout} = await execProm(`git diff --name-only ${base} --relative`, {

--- a/git-changed-files.js
+++ b/git-changed-files.js
@@ -2,61 +2,7 @@
 const execProm = require('./exec-prom');
 const path = require('path');
 const fs = require('fs');
-const minimatch = require('minimatch'); // flow-uncovered-line
-
-// ok
-const getIgnoredPatterns = (fileContents /*: string*/) => {
-    return fileContents
-        .split('\n')
-        .map(line => {
-            if (line.startsWith('#')) {
-                return null;
-            }
-            if (line.startsWith('"')) {
-                throw new Error('Quoted patterns not yet supported, sorry');
-            }
-            if (!line.trim()) {
-                return null;
-            }
-            const [pattern, ...attributes] = line.trim().split(' ');
-            if (attributes.includes('binary') || attributes.includes('linguist-generated=true')) {
-                return pattern;
-            }
-            return null;
-        })
-        .filter(Boolean);
-};
-
-const ignoredPatternsByDirectory /*: {[key: string]: Array<string>}*/ = {};
-const isFileIgnored = (workingDirectory /*: string*/, file /*: string*/) => {
-    // If it's outside of the "working directory", we ignore it
-    if (!file.startsWith(workingDirectory)) {
-        return true;
-    }
-    let dir = path.dirname(file);
-    let name = path.basename(file);
-    while (dir.startsWith(workingDirectory)) {
-        if (!ignoredPatternsByDirectory[dir]) {
-            const attributes = path.join(dir, '.gitattributes');
-            if (fs.existsSync(attributes)) {
-                ignoredPatternsByDirectory[dir] = getIgnoredPatterns(
-                    fs.readFileSync(attributes, 'utf8'),
-                );
-            } else {
-                ignoredPatternsByDirectory[dir] = [];
-            }
-        }
-        for (const pattern of ignoredPatternsByDirectory[dir]) {
-            // flow-next-uncovered-line
-            if (minimatch(name, pattern)) {
-                return true;
-            }
-        }
-        name = path.join(path.basename(dir), name);
-        dir = path.dirname(dir);
-    }
-    return false;
-};
+const isFileIgnored = require('./is-file-ignored');
 
 /**
  * This lists the files that have changed when compared to `base` (a git ref),
@@ -67,22 +13,6 @@ const isFileIgnored = (workingDirectory /*: string*/, file /*: string*/) => {
 const gitChangedFiles = async (base /*:string*/, cwd /*:string*/) /*: Promise<Array<string>>*/ => {
     cwd = path.resolve(cwd);
 
-    // Github actions jobs can run the following steps to get a fully accurate
-    // changed files list. Otherwise, we fallback to a simple diff between the
-    // current and base branch, which might give false positives if the base
-    // is ahead of the current branch.
-    //
-    //   - name: Get All Changed Files
-    //     uses: jaredly/get-changed-files@absolute
-    //     id: changed
-    //     with:
-    //       format: 'json'
-    //       absolute: true
-    //
-    //   - uses: allenevans/set-env@v2.0.0
-    //     with:
-    //       ALL_CHANGED_FILES: '${{ steps.changed.outputs.added_modified }}'
-    //
     if (process.env.ALL_CHANGED_FILES) {
         const files /*: Array<string> */ = JSON.parse(process.env.ALL_CHANGED_FILES); // flow-uncovered-line
         return files.filter(path => !isFileIgnored(cwd, path));

--- a/is-file-ignored.js
+++ b/is-file-ignored.js
@@ -3,7 +3,6 @@ const path = require('path');
 const fs = require('fs');
 const minimatch = require('minimatch'); // flow-uncovered-line
 
-// ok
 const getIgnoredPatterns = (fileContents /*: string*/) => {
     return fileContents
         .split('\n')

--- a/is-file-ignored.js
+++ b/is-file-ignored.js
@@ -1,0 +1,60 @@
+// @flow
+const path = require('path');
+const fs = require('fs');
+const minimatch = require('minimatch'); // flow-uncovered-line
+
+// ok
+const getIgnoredPatterns = (fileContents /*: string*/) => {
+    return fileContents
+        .split('\n')
+        .map(line => {
+            if (line.startsWith('#')) {
+                return null;
+            }
+            if (line.startsWith('"')) {
+                throw new Error('Quoted patterns not yet supported, sorry');
+            }
+            if (!line.trim()) {
+                return null;
+            }
+            const [pattern, ...attributes] = line.trim().split(' ');
+            if (attributes.includes('binary') || attributes.includes('linguist-generated=true')) {
+                return pattern;
+            }
+            return null;
+        })
+        .filter(Boolean);
+};
+
+const ignoredPatternsByDirectory /*: {[key: string]: Array<string>}*/ = {};
+const isFileIgnored = (workingDirectory /*: string*/, file /*: string*/) => {
+    // If it's outside of the "working directory", we ignore it
+    if (!file.startsWith(workingDirectory)) {
+        return true;
+    }
+    let dir = path.dirname(file);
+    let name = path.basename(file);
+    while (dir.startsWith(workingDirectory)) {
+        if (!ignoredPatternsByDirectory[dir]) {
+            const attributes = path.join(dir, '.gitattributes');
+            if (fs.existsSync(attributes)) {
+                ignoredPatternsByDirectory[dir] = getIgnoredPatterns(
+                    fs.readFileSync(attributes, 'utf8'),
+                );
+            } else {
+                ignoredPatternsByDirectory[dir] = [];
+            }
+        }
+        for (const pattern of ignoredPatternsByDirectory[dir]) {
+            // flow-next-uncovered-line
+            if (minimatch(name, pattern)) {
+                return true;
+            }
+        }
+        name = path.join(path.basename(dir), name);
+        dir = path.dirname(dir);
+    }
+    return false;
+};
+
+module.exports = isFileIgnored;


### PR DESCRIPTION
## Summary:
This will help us move eslint/jest/flow-action away from needing to have the base ref checked out.

Issue: none

## Test plan:
This is just moving some logic around. Checks should all pass.