### PR TITLE
Remove usage of deprecated set-output action

### DIFF
--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -20,13 +20,13 @@ jobs:
 
           then
 
-          echo "::set-output name=changed::true"
+          echo "name=changed::true" >> $GITHUB_STATE
 
           exit 0
 
           fi
 
-          echo "::set-output name=changed::false"
+          echo "name=changed::false" >> $GITHUB_STATE
 
           exit 0
       - run: yarn

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -20,13 +20,13 @@ jobs:
 
           then
 
-          echo "name=changed::true" >> $GITHUB_STATE
+          echo "name=changed::true" >> $GITHUB_OUTPUT
 
           exit 0
 
           fi
 
-          echo "name=changed::false" >> $GITHUB_STATE
+          echo "name=changed::false" >> $GITHUB_OUTPUT
 
           exit 0
       - run: yarn


### PR DESCRIPTION
## Summary:

As I was fixing our mobile actions to use node16 everywhere, I also noticed a deprecation warning for using `::set-output` (more info [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)). 

This PR updates this repo to use the new syntax.

Issue: "none"

## Test plan:

Review it visually. I'll update the mobile repo to start using this on the branch to test.